### PR TITLE
Make discli installable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,15 @@
 .discli
+
+#python
+*.pyc
+*.pyx
+*.pyo
+
+# build artifacts
+build/
+discli.egg-info/
+dist/
+
+# editors, etc
+.idea/
+.vscode/

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+PyYAML>=5.1
+requests>=2.22

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,24 @@
+from setuptools import setup
+
+setup(
+    name="discli",
+    version='0.1.dev1',
+    description="A ",
+    author="Tim Penhey",
+    author_email="tim@canonical.com",
+    scripts=["discli"],
+    license='MIT',
+    python_requires=">= 3.4",
+    install_requires=[
+      "requests>=2.22",
+      "PyYAML>=5.1",
+    ],
+    classifiers=[
+        'Development Status :: 3 - Alpha',
+        'Environment :: Console',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: MIT License',
+        'Topic :: Internet :: WWW/HTTP :: Dynamic Content :: Message Boards',
+        'Topic :: Internet :: WWW/HTTP :: Dynamic Content :: Wiki',
+    ]
+)


### PR DESCRIPTION
This PR adds a `setup.py` file with a scripts target so that the `discli` command can easily be installed to the PATH.